### PR TITLE
错误提示统一由amis展示

### DIFF
--- a/packages/core/src/utils/request/index.ts
+++ b/packages/core/src/utils/request/index.ts
@@ -104,7 +104,7 @@ function cacheSourceCtrl(type: 'set' | 'get', option: Types.ReqOption, resource?
 
   if (type === 'set') {
     // 不存在 resource 直接返回
-    if (!resource) {
+    if (!resource || resource?.status !== 0) {
       return
     }
     // 所有数据按照 字符串缓存

--- a/packages/core/src/utils/request/index.ts
+++ b/packages/core/src/utils/request/index.ts
@@ -20,8 +20,15 @@ const log = logger.getLogger('lib:utils:request')
 // 请求错误集中处理， 必须 throw 错误
 function requestErrorCtrl(this: Request, error: Error, option: Types.ReqOption, response?: any) {
   // log.info('requestErrorCtrl', { error, option, response })
-  const errorSource = { option, response, error }
+  // const errorSource = { option, response, error }
 
+  // 设置默认的错误信息
+  response.data = {
+    status: 400,
+    msg: error.message || '未知错误',
+    ...response.data,
+  }
+  
   let withInsErrorHook = true
 
   // 如果返回 false，则不调用 全局的错误处理
@@ -37,7 +44,7 @@ function requestErrorCtrl(this: Request, error: Error, option: Types.ReqOption, 
     this.onFinish(response, option, error)
   }
 
-  throw errorSource
+  // throw errorSource
 }
 
 // 请求成功集中处理
@@ -162,16 +169,16 @@ async function fetchSourceCtrl(this: Request, option: Types.ReqOption) {
           option,
           wrapResponse(response)
         )
-        return
+        return response
       }
 
       try {
         response.data = await readJsonResponse(response)        
-        requestSuccessCtrl.call(this, response, option)
-        return response
+        requestSuccessCtrl.call(this, response, option)        
       } catch (error) {
         requestErrorCtrl.call(this, error, option, wrapResponse(response))
       }
+      return response
     })
 
   return result


### PR DESCRIPTION
发生错误时`fetchSourceCtrl`正常返回`response`，在`requestErrorCtrl`中设置默认的错误信息，onError回调可以对错误信息进行定制，最后统一由amis进行提示