### PR TITLE
优化 limit-setting 组件

### DIFF
--- a/packages/core/src/components/limit_setting/index.tsx
+++ b/packages/core/src/components/limit_setting/index.tsx
@@ -86,7 +86,6 @@ const LimitSetting = (props: LimitSettingProps) => {
   const onTreeChange = (value: string) => {
     const limitValue = resolveSelectVal(menuConfig, value)
     storeRef.current[activeTab] = limitValue
-
     setState((d) => {
       d.selectedVal = limitValue
       d.isUnfolded = undefined
@@ -190,7 +189,7 @@ const LimitSetting = (props: LimitSettingProps) => {
                   multiple
                   joinValues
                   onlyChildren
-                  initiallyOpen={!isUnfolded}
+                  initiallyOpen={isUnfolded}
                   value={selectedVal}
                   valueField="nodePath"
                   options={item.children}
@@ -211,7 +210,6 @@ function resolveSelectVal(menusConfig: any[], limitValue: string) {
 
   eachTree<LimitMenuItem>(menusConfig, (item) => {
     const { needs, nodePath } = item
-
     if (!needs || isSubStr(nodePath, routeLimitKey)) {
       return
     }
@@ -241,7 +239,6 @@ function resolveLimitMenus(menusConfig: any[], option: { limitValue: string }) {
   return mapTree<LimitItem>(menusConfig, (item) => {
     const { needs, nodePath } = item
     // item.unfolded = isUnfolded
-
     if (!needs || isSubStr(nodePath, routeLimitKey)) {
       return item
     }
@@ -260,6 +257,7 @@ function getAllAuthLimitStr(
   store: ObjectOf<string>
 ): string {
   const limitValue: string[] = []
+
   map(store, (value, storeTab) => {
     const index = Number(storeTab)
     if (value && visitedTabs.findIndex((tab) => tab === index) > -1) {

--- a/packages/core/src/components/limit_setting/index.tsx
+++ b/packages/core/src/components/limit_setting/index.tsx
@@ -86,6 +86,7 @@ const LimitSetting = (props: LimitSettingProps) => {
   const onTreeChange = (value: string) => {
     const limitValue = resolveSelectVal(menuConfig, value)
     storeRef.current[activeTab] = limitValue
+
     setState((d) => {
       d.selectedVal = limitValue
       d.isUnfolded = undefined
@@ -188,9 +189,8 @@ const LimitSetting = (props: LimitSettingProps) => {
                   hideRoot
                   multiple
                   joinValues
-                  cascade
-                  withChildren
-                  initiallyOpen={isUnfolded}
+                  onlyChildren
+                  initiallyOpen={!isUnfolded}
                   value={selectedVal}
                   valueField="nodePath"
                   options={item.children}
@@ -211,6 +211,7 @@ function resolveSelectVal(menusConfig: any[], limitValue: string) {
 
   eachTree<LimitMenuItem>(menusConfig, (item) => {
     const { needs, nodePath } = item
+
     if (!needs || isSubStr(nodePath, routeLimitKey)) {
       return
     }
@@ -239,7 +240,6 @@ function resolveLimitMenus(menusConfig: any[], option: { limitValue: string }) {
 
   return mapTree<LimitItem>(menusConfig, (item) => {
     const { needs, nodePath } = item
-
     // item.unfolded = isUnfolded
 
     if (!needs || isSubStr(nodePath, routeLimitKey)) {
@@ -260,7 +260,6 @@ function getAllAuthLimitStr(
   store: ObjectOf<string>
 ): string {
   const limitValue: string[] = []
-
   map(store, (value, storeTab) => {
     const index = Number(storeTab)
     if (value && visitedTabs.findIndex((tab) => tab === index) > -1) {

--- a/packages/core/src/routes/limit/exports.ts
+++ b/packages/core/src/routes/limit/exports.ts
@@ -31,7 +31,7 @@ export const convertLimitStr = (limitStr: string = '') => {
   return tpl
 }
 
-// 处理 onlyChildren 导致的父级不再的问题
+// 处理 onlyChildren 导致的父级不在的问题
 function addLimitParent(limits: any[]): string {
   const limitOrigin: any = {}
   const newLimitObj: any = {}

--- a/packages/core/src/routes/limit/exports.ts
+++ b/packages/core/src/routes/limit/exports.ts
@@ -31,8 +31,30 @@ export const convertLimitStr = (limitStr: string = '') => {
   return tpl
 }
 
+// 处理 onlyChildren 导致的父级不再的问题
+function addLimitParent(limits: any[]): string {
+  const limitOrigin: any = {}
+  const newLimitObj: any = {}
+  limits.forEach((item) => {
+    limitOrigin[`${item.slice(0, item.lastIndexOf('/'))}`] = 1
+    newLimitObj[item] = 1
+  })
+
+  Object.keys(limitOrigin).forEach((item) => {
+    const limitPath = item.split('/').slice(1, item.length + 1)
+    limitPath.forEach((_val: string, i: number) => {
+      newLimitObj[`/${limitPath.slice(0, i + 1).join('/')}`] = 1
+    })
+  })
+
+  // 去重
+  const delRepeatLimit = Object.keys(newLimitObj)
+
+  return delRepeatLimit.join(',')
+}
+
 export const setAppLimits = (limitStr: string) => {
-  store = convertLimitStr(limitStr)
+  store = convertLimitStr(addLimitParent(limitStr.split(',')))
 }
 
 export const getAppLimits = () => store


### PR DESCRIPTION
Q: 由于Amis tree 升级导致 limit-setting 组件在父级全选保存后，后续添加子选项会默认被选中